### PR TITLE
Flow Rosetta v0.4.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,13 @@ config file:
     hatch in case any of the existing protection against cache poisoning fails
     for some reason.
 
+* `max_backoff_interval: string`
+
+  * When encountering certain API errors, we exponentially back off from two
+    seconds up to the given max backoff interval. This accepts [time.Duration
+    values](https://pkg.go.dev/time#ParseDuration) like `"1s"`, `"30s"`, etc. If
+    no value has been set, this will default to 10 seconds.
+
 * `mode: "online" | "offline"`
 
   * This specifies whether the Flow Rosetta should work in online or offline

--- a/model/model.go
+++ b/model/model.go
@@ -4,6 +4,7 @@ package model
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/onflow/flow/protobuf/go/flow/entities"
@@ -28,6 +29,31 @@ func (b *BlockMeta) Equal(other *BlockMeta) bool {
 	}
 	return bytes.Equal(b.Hash, other.Hash) &&
 		b.Height == other.Height && b.Timestamp == other.Timestamp
+}
+
+// Pretty generates a custom-formatted representation of an operation.
+func (o *Operation) Pretty() string {
+	w := &strings.Builder{}
+	w.WriteByte('{')
+	if len(o.Account) == 0 {
+		w.WriteString("account: nil, ")
+	} else {
+		fmt.Fprintf(w, `account: "0x%x", `, o.Account)
+	}
+	fmt.Fprintf(w, "amount: %v, ", o.Amount)
+	if len(o.ProxyPublicKey) == 0 {
+		w.WriteString("proxy_public_key: nil, ")
+	} else {
+		fmt.Fprintf(w, `proxy_public_key: "%x", `, o.ProxyPublicKey)
+	}
+	if len(o.Receiver) == 0 {
+		w.WriteString("receiver: nil, ")
+	} else {
+		fmt.Fprintf(w, `receiver: "0x%x", `, o.Receiver)
+	}
+	fmt.Fprintf(w, `type: "%s"`, o.Type)
+	w.WriteByte('}')
+	return w.String()
 }
 
 // NOTE(tav): The ordering of the fields matter for the following data types, as

--- a/version/version.go
+++ b/version/version.go
@@ -3,5 +3,5 @@ package version
 
 const (
 	Flow        = "0.26.6"
-	FlowRosetta = "0.4.20"
+	FlowRosetta = "0.4.22"
 )


### PR DESCRIPTION
This PR:

* Introduces a new `max_backoff_interval` config parameter that defines the upper limit when exponentially backing off from certain Access API errors. This defaults to `10s` and is used to back off more aggressively in certain conditions.

* Adds a custom `/call` method `balance_validation_status` that returns the status of the balance validation check. The `result.status` can be one of `not_started`, `in_progress`, `success`, or `failure`.

* Improves the log output of `model.Operation` values, e.g. prints account addresses properly, etc.

* Defines placeholder Cadence scripts for deploying/updating contracts while rotating the corresponding account's public key.

* Fixes up the Consensus Follower support so that it is not constrained by the speed at which new blocks are synced.

* Adds a comment regarding the upcoming support in `flow-go` for configuring Consensus Follower with `compliance.WithSkipNewProposalsThreshold` which should allow for it to finally be used in production.