### PR TITLE
Add tools to print txinfo and verifysig

### DIFF
--- a/cmd/txinfo/txinfo.go
+++ b/cmd/txinfo/txinfo.go
@@ -1,0 +1,41 @@
+// Command txinfo prints information about a transaction.
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/onflow/rosetta/access"
+	"github.com/onflow/rosetta/log"
+)
+
+var networks = map[string]string{
+	"mainnet": "access.mainnet.nodes.onflow.org:9000",
+	"testnet": "access.devnet.nodes.onflow.org:9000",
+	"canary":  "access.canary.nodes.onflow.org:9000",
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Println("Usage: txinfo mainnet|testnet|canary <txhash>")
+		os.Exit(1)
+	}
+	addr, ok := networks[os.Args[1]]
+	if !ok {
+		log.Fatalf("Unsupported network: %q", os.Args[1])
+	}
+	hash, err := hex.DecodeString(os.Args[2])
+	if err != nil {
+		log.Fatalf("Failed to hex-decode txhash %q: %s", os.Args[2], err)
+	}
+	ctx := context.Background()
+	pool := access.New(ctx, []access.NodeConfig{{Address: addr}}, nil)
+	client := pool.Client()
+	tx, err := client.TransactionResultByHash(ctx, hash)
+	if err != nil {
+		log.Fatalf("Failed to find txinfo: %s", err)
+	}
+	log.Infof("Transaction %x: %#v", hash, tx)
+}

--- a/cmd/verifysig/verifysig.go
+++ b/cmd/verifysig/verifysig.go
@@ -1,0 +1,57 @@
+// Command verifysig verifies the signature produced by the given key for a
+// message.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+	"github.com/onflow/rosetta/log"
+)
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Println("Usage: verifysig <public-key> <message> <signature>")
+		os.Exit(1)
+	}
+	publicKey, rawMessage, rawSignature := os.Args[1], os.Args[2], os.Args[3]
+	raw, err := hex.DecodeString(publicKey)
+	if err != nil {
+		log.Errorf(
+			"Failed to hex-decode secp256k1 key %q: %s",
+			publicKey, err,
+		)
+	}
+	pub, err := secp256k1.ParsePubKey(raw)
+	if err != nil {
+		log.Errorf(
+			"Failed to parse secp256k1 key %q: %s",
+			publicKey, err,
+		)
+	}
+	raw, err = hex.DecodeString(rawSignature)
+	if err != nil {
+		log.Errorf(
+			"Failed to hex-decode signature %q: %s",
+			rawSignature, err,
+		)
+	}
+	sig, err := ecdsa.ParseDERSignature(raw)
+	if err != nil {
+		log.Errorf(
+			"Failed to DER-decode signature %q: %s",
+			rawSignature, err,
+		)
+	}
+	hash := sha256.Sum256([]byte(rawMessage))
+	ok := sig.Verify(hash[:], pub)
+	if ok {
+		log.Infof("Valid signature found")
+	} else {
+		log.Fatalf("Invalid signature found")
+	}
+}


### PR DESCRIPTION
This PR adds two new tools:

1. `cmd/txinfo` will print the transaction result for a given network and transaction hash.

```
Usage: txinfo mainnet|testnet|canary <txhash>
```

2. `cmd/verifysig` will verify a signature produced by the given public key over the specified message.

```
Usage: verifysig <public-key> <message> <signature>
```