### PR TITLE
Flow Rosetta v0.4.25

### DIFF
--- a/api/account_service.go
+++ b/api/account_service.go
@@ -175,8 +175,17 @@ func (s *Server) getSequenceNumber(ctx context.Context, addr []byte, block *mode
 	if err != nil {
 		return 0, err
 	}
-	if len(acct.Keys) != 1 {
-		return 0, fmt.Errorf("found %d keys on the account: expected just one", len(acct.Keys))
+	count := 0
+	seq := uint64(0)
+	for _, key := range acct.Keys {
+		if key.Revoked {
+			continue
+		}
+		seq = uint64(key.SequenceNumber)
+		count++
 	}
-	return uint64(acct.Keys[0].SequenceNumber), nil
+	if count != 1 {
+		return 0, fmt.Errorf("found %d valid keys out of total %d keys", count, len(acct.Keys))
+	}
+	return seq, nil
 }

--- a/state/state.go
+++ b/state/state.go
@@ -650,7 +650,7 @@ func (i *Indexer) runConsensusFollower(ctx context.Context) {
 	if err != nil || n != flowcrypto.KeyGenSeedMinLenECDSASecp256k1 {
 		log.Fatalf("Could not generate seed for the consensus follower private key")
 	}
-	key, err := utils.GenerateUnstakedNetworkingKey(seed)
+	key, err := utils.GeneratePublicNetworkingKey(seed)
 	if err != nil {
 		log.Fatalf("Could not generate the consensus follower private key")
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -3,5 +3,5 @@ package version
 
 const (
 	Flow        = "0.27.0"
-	FlowRosetta = "0.4.24"
+	FlowRosetta = "0.4.25"
 )


### PR DESCRIPTION
This PR:

* Changes the logic within the `/account/balance` handler to only return the sequence number from the currently active key, and to ignore revoked keys when validating the total number of keys on an account.

* Renames `utils.GenerateUnstakedNetworkingKey` to match the upstream change within `flow-go`.