### PR TITLE
Fix execution result check for blocks without seals

### DIFF
--- a/state/convert_test.go
+++ b/state/convert_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/rosetta/access"
 	"github.com/onflow/rosetta/config"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,50 @@ func TestVerifyBlockHash(t *testing.T) {
 			assert.Fail(t, err.Error())
 		}
 		assert.True(t, verifyBlockHash(spork, block.Id, blockHeight, blockHeader, block))
+	}
+}
+
+func TestVerifyExecutionResultHash(t *testing.T) {
+	var startBlockHeight uint64 = 55114464
+	var endBlockHeight uint64 = 55114465
+	ctx := context.Background()
+	spork, err := createSpork(ctx)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	client := spork.AccessNodes.Client()
+	var sealedResults map[string]string
+	for blockHeight := startBlockHeight; blockHeight < endBlockHeight; blockHeight++ {
+		block, err := client.BlockByHeight(ctx, blockHeight)
+		if err != nil {
+			assert.Fail(t, err.Error())
+		}
+		execResult, err := client.ExecutionResultForBlockID(ctx, block.Id)
+		if err != nil {
+			assert.Fail(t, err.Error())
+		}
+		for _, seal := range block.BlockSeals {
+			sealedResults[string(seal.BlockId)] = string(seal.ResultId)
+		}
+		var resultID flow.Identifier
+		var resultIDV5 flow.Identifier
+		exec, ok := convertExecutionResult(block.Id, blockHeight, execResult)
+		if ok {
+			resultID = deriveExecutionResult(spork, exec)
+		}
+		execV5, okV5 := convertExecutionResultV5(block.Id, blockHeight, execResult)
+		if okV5 {
+			resultIDV5 = deriveExecutionResultV5(execV5)
+		}
+		if !ok && !okV5 {
+			assert.Fail(t, "unable to covert from either hash")
+		}
+		sealedResult, foundOk := sealedResults[string(block.Id)]
+		if foundOk {
+			if string(resultID[:]) != sealedResult && string(resultIDV5[:]) != sealedResult {
+				assert.Fail(t, "target error")
+			}
+		}
 	}
 }
 

--- a/state/process.go
+++ b/state/process.go
@@ -325,25 +325,25 @@ outer:
 			}
 			var resultID flow.Identifier
 			var resultIDV5 flow.Identifier
-			exec, ok := convertExecutionResult(hash, height, execResult)
-			if ok {
+			exec, convOk := convertExecutionResult(hash, height, execResult)
+			if convOk {
 				resultID = deriveExecutionResult(spork, exec)
 			}
-			execV5, okV5 := convertExecutionResultV5(hash, height, execResult)
-			if okV5 {
+			execV5, convOkV5 := convertExecutionResultV5(hash, height, execResult)
+			if convOkV5 {
 				resultIDV5 = deriveExecutionResultV5(execV5)
 			}
-			if !ok && !okV5 {
+			if !convOk && !convOkV5 {
 				skipCache = true
 				continue
 			}
-			sealedResult, ok := i.sealedResults[string(hash)]
+			sealedResult, foundOk := i.sealedResults[string(hash)]
 			// NOTE(tav): Skip the execution result check for the root block of
 			// a spork as it is self-sealed.
 			if spork.Prev != nil && height == spork.RootBlock {
-				sealedResult, ok = string(resultID[:]), true
+				sealedResult, foundOk = string(resultID[:]), true
 			}
-			if ok || okV5 {
+			if foundOk {
 				if string(resultID[:]) != sealedResult && string(resultIDV5[:]) != sealedResult {
 					log.Errorf(
 						"Got mismatching execution result hash for block %x at height %d: expected %x, got %x",


### PR DESCRIPTION
making a PR now, it just so happens that the last few blocks of the spork don’t carry seals, but the code isn’t able to reach this block: https://github.com/onflow/rosetta/blob/4f20d064745893b4a6099df5783dee052068bd37/state/process.go#L360-L377