### PR TITLE
Update convert tests

### DIFF
--- a/state/convert_test.go
+++ b/state/convert_test.go
@@ -105,13 +105,13 @@ func VerifyExecutionResultsForSpork(t *testing.T, ctx context.Context, spork *co
 		require.NoError(t, err)
 		// Store the Result ID for any seals of previous blocks
 		for _, seal := range block.BlockSeals {
-			sealedResults[flow.Identifier(seal.BlockId)] = flow.Identifier(seal.ResultId)
+			sealedResults[toFlowIdentifier(seal.BlockId)] = toFlowIdentifier(seal.ResultId)
 		}
 		// Compute the result ID for the current block
 		exec, ok := convertExecutionResult(spork.Version, block.Id, blockHeight, execResult)
 		require.True(t, ok, "unable to convert execution result")
 		resultID := deriveExecutionResult(spork, exec)
-		computedResults[flow.Identifier(block.Id)] = resultID
+		computedResults[toFlowIdentifier(block.Id)] = resultID
 	}
 	checkedResults := 0
 	for blockID := range computedResults {


### PR DESCRIPTION
Allow testing on different spork versions, and fix a test that didn't verify what it claimed to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Refactored verification tests to use template-driven network configurations with per-version subtests.
  - Added reusable helpers to verify blocks and execution results over explicit height ranges.
  - Improved header-based hash verification and strengthened assertions for seals, events, and computed results.
  - Replaced legacy helpers with unified templates to reduce duplication and improve error reporting and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->