### PR TITLE
Use correct cadence type in cast

### DIFF
--- a/api/construction_service.go
+++ b/api/construction_service.go
@@ -1428,10 +1428,10 @@ func decodeTransferOps(txn *entities.Transaction, proxy bool, signed bool) (*typ
 			errInvalidTransactionPayload, "unable to decode amount transaction arg: %s", err,
 		)
 	}
-	amount, ok := raw.(cadence.UInt64)
+	amount, ok := raw.(cadence.UFix64)
 	if !ok {
 		return nil, wrapErrorf(
-			errInvalidTransactionPayload, "unable to convert amount transaction arg to uint64",
+			errInvalidTransactionPayload, "unable to convert amount transaction arg to ufix64",
 		)
 	}
 	if proxy {


### PR DESCRIPTION
When parsing arguments to the `basic-transfer.cdc` transaction, should use the correct cadence type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transaction amount handling to support decimal precision values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->