### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*.cdc @onflow/flow-smart-contracts
+* @onflow/flow-core-protocol


### PR DESCRIPTION
Consolidate code ownership onto the `@onflow/flow-core-protocol` team.

This also removes the `*.cdc @onflow/flow-smart-contracts` rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignment for repository files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->